### PR TITLE
Log sort implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const LogSource = require("./lib/log-source");
 const Printer = require("./lib/printer");
 
-function runSolutions(sourceCount) {
+function drainSynchronousLogs(sourceCount) {
   return new Promise((resolve, reject) => {
     /**
      * Challenge Number 1!
@@ -35,31 +35,40 @@ function runSolutions(sourceCount) {
     } catch (e) {
       reject(e);
     }
-  }).then(() => {
-    return new Promise((resolve, reject) => {
-      /**
-       * Challenge Number 2!
-       *
-       * Similar to Challenge Number 1, except now you should assume that a LogSource
-       * has only one method: popAsync() which returns a promise that resolves with a LogEntry,
-       * or boolean false once the LogSource has ended.
-       *
-       * Your job is simple: print the sorted merge of all LogEntries across `n` LogSources.
-       *
-       * Call `printer.print(logEntry)` to print each entry of the merged output as they are ready.
-       * This function will ensure that what you print is in fact in chronological order.
-       * Call 'printer.done()' at the end to get a few stats on your solution!
-       */
-      const asyncLogSources = [];
-      for (let i = 0; i < sourceCount; i++) {
-        asyncLogSources.push(new LogSource());
-      }
-      require("./solution/async-sorted-merge")(asyncLogSources, new Printer())
-        .then(resolve)
-        .catch(reject);
-    });
+  })
+}
+
+function drainAsynchronousLogs(sourceCount) {
+  return new Promise((resolve, reject) => {
+    /**
+     * Challenge Number 2!
+     *
+     * Similar to Challenge Number 1, except now you should assume that a LogSource
+     * has only one method: popAsync() which returns a promise that resolves with a LogEntry,
+     * or boolean false once the LogSource has ended.
+     *
+     * Your job is simple: print the sorted merge of all LogEntries across `n` LogSources.
+     *
+     * Call `printer.print(logEntry)` to print each entry of the merged output as they are ready.
+     * This function will ensure that what you print is in fact in chronological order.
+     * Call 'printer.done()' at the end to get a few stats on your solution!
+     */
+    const asyncLogSources = [];
+    for (let i = 0; i < sourceCount; i++) {
+      asyncLogSources.push(new LogSource());
+    }
+    require("./solution/async-sorted-merge")(asyncLogSources, new Printer())
+      .then(resolve)
+      .catch(reject);
   });
 }
 
+function runSolutions(sourceCount) {
+  // return drainSynchronousLogs(sourceCount).then(() => {
+  //   return drainAsynchronousLogs(sourceCount);
+  // });
+  return drainAsynchronousLogs(sourceCount);
+}
+
 // Adjust this input to see how your solutions perform under various loads.
-runSolutions(100);
+runSolutions(1000);

--- a/index.js
+++ b/index.js
@@ -64,11 +64,10 @@ function drainAsynchronousLogs(sourceCount) {
 }
 
 function runSolutions(sourceCount) {
-  // return drainSynchronousLogs(sourceCount).then(() => {
-  //   return drainAsynchronousLogs(sourceCount);
-  // });
-  return drainAsynchronousLogs(sourceCount);
+  return drainSynchronousLogs(sourceCount).then(() => {
+    return drainAsynchronousLogs(sourceCount);
+  });
 }
 
 // Adjust this input to see how your solutions perform under various loads.
-runSolutions(1000);
+runSolutions(10);

--- a/solution/async-sorted-merge.js
+++ b/solution/async-sorted-merge.js
@@ -1,8 +1,105 @@
 "use strict";
 
-// Print all entries, across all of the *async* sources, in chronological order.
+const MAX_NUM_LOGS_TO_READ_AHEAD = 5
 
-module.exports = (logSources, printer) => {
+// Print all entries, across all of the *async* sources, in chronological order.
+const fillNextLogsArray = (source, nextLogsArray) => {
+  if(!source) { throw new Error('Log source not valid') }
+
+  while (nextLogsArray.length < MAX_NUM_LOGS_TO_READ_AHEAD) {
+    // Call popAsync to request log message but do not block waiting for
+    // promise to be fulfilled.
+
+    // ERROR: This strategy appears to trigger a race condition!
+    nextLogsArray.push(source.popAsync());
+  }
+
+  return nextLogsArray;
+}
+
+const getIndexOfNextLogObject = (logObjs) => {
+  let nextIndex = null
+
+  /*
+    Iterate through the log object array and find the index of the object
+    with the next log message in chronological sequence by comparing log dates
+    with a minimum.
+
+    This method is O(n) time complexity where n is the number of log sources.
+  */
+  logObjs.forEach((obj, index) => {
+    if (!obj.nextLog) { return; }
+
+    if (nextIndex === null || obj.nextLog.date < logObjs[nextIndex].nextLog.date) {
+      nextIndex = index;
+    }
+  });
+
+  return nextIndex;
+}
+
+const updateLogObject = async (logObj) => {
+  if (!logObj.nextLogsPromises || logObj.nextLogsPromises.length === 0) {
+    logObj.nextLog = null
+    return;
+  }
+
+  const nextLogPromise = logObj.nextLogsPromises.shift();
+  logObj.nextLog = await nextLogPromise;
+
+  if (logObj.nextLog) {
+    fillNextLogsArray(logObj.source, logObj.nextLogsPromises);
+  }
+
+  return;
+}
+
+const populateNextLogs = async (logObjs) => {
+  const nextLogPromises = logObjs.map((logObj) => {
+    return updateLogObject(logObj).then(() => logObj.nextLog);
+  });
+
+  await Promise.all(nextLogPromises);
+}
+
+
+const logsRemain = (logObjs) => {
+  return logObjs.some((obj) => !!obj.nextLog);
+}
+
+
+module.exports = async (logSources, printer) => {
+  // Similar to synchronous solution, create object array to hold sources and next logs
+  const logsObjArray = logSources.map((source) => {
+    return {
+      source: source,
+      nextLog: null,
+      nextLogsPromises: fillNextLogsArray(source, []) // Array of promises. We are attempting to read ahead to give the async logs time to populate
+    }
+  });
+
+  do {
+    /*
+      We cannot make any assessment of log ordering until we have waited for
+      all sources to return at least 1 result (even if that result indicates the log is drained)
+      We must block execution until all the nextLog values are resolved
+    */
+    await populateNextLogs(logsObjArray);
+
+    // Now this problem reduces to the synchonous case since we should have the next log for
+    // each source
+    const nextLogIndex = getIndexOfNextLogObject(logsObjArray);
+
+    if (nextLogIndex === null) { break; }
+
+    printer.print(logsObjArray[nextLogIndex].nextLog);
+
+    updateLogObject(logsObjArray[nextLogIndex])
+
+  } while(logsRemain(logsObjArray))
+
+  printer.done();
+
   return new Promise((resolve, reject) => {
     resolve(console.log("Async sort complete."));
   });

--- a/solution/sync-sorted-merge.js
+++ b/solution/sync-sorted-merge.js
@@ -1,7 +1,54 @@
 "use strict";
 
+const getIndexOfNextLogObject = (logObjs) => {
+  let nextIndex = null
+
+  /*
+    Iterate through the log object array and find the index of the object
+    with the next log message in chronological sequence by comparing log dates
+    with a minimum.
+
+    This method is O(n) time complexity where n is the number of log sources.
+  */
+  logObjs.forEach((obj, index) => {
+    if (!obj.nextLog) { return; }
+
+    if (nextIndex === null || obj.nextLog.date < logObjs[nextIndex].nextLog.date) {
+      nextIndex = index;
+    }
+  });
+
+  return nextIndex;
+}
+
+const logsRemain = (logObjs) => {
+  return logObjs.some((obj) => !!obj.nextLog);
+}
+
 // Print all entries, across all of the sources, in chronological order.
 
 module.exports = (logSources, printer) => {
+  // Create an array holding the source and next element for each log source
+  // Space complexity is O(n) where n is number of log sources
+  const logsObjArray = logSources.map((source) => {
+    return {
+      source: source,
+      nextLog: source.pop()
+    };
+  });
+
+  // Operate while logs remain to be printed
+  // This loop is O(m) time complexity where m is the number of messages across all sources
+  while(logsRemain(logsObjArray)) {
+    const nextLogIndex = getIndexOfNextLogObject(logsObjArray);
+
+    if (!nextLogIndex) {
+      break;
+    }
+
+    printer.print(logsObjArray[nextLogIndex].nextLog);
+    logsObjArray[nextLogIndex].nextLog = logsObjArray[nextLogIndex].source.pop();
+  }
+
   return console.log("Sync sort complete.");
 };

--- a/solution/sync-sorted-merge.js
+++ b/solution/sync-sorted-merge.js
@@ -21,10 +21,6 @@ const getIndexOfNextLogObject = (logObjs) => {
   return nextIndex;
 }
 
-const logsRemain = (logObjs) => {
-  return logObjs.some((obj) => !!obj.nextLog);
-}
-
 // Print all entries, across all of the sources, in chronological order.
 
 module.exports = (logSources, printer) => {
@@ -40,7 +36,7 @@ module.exports = (logSources, printer) => {
 
   // Operate while logs remain to be printed
   // This loop is O(m) time complexity where m is the number of messages across all sources
-  while(logsRemain(logsObjArray)) {
+  while (true) {
     const nextLogIndex = getIndexOfNextLogObject(logsObjArray);
 
     if (nextLogIndex === null) {

--- a/solution/sync-sorted-merge.js
+++ b/solution/sync-sorted-merge.js
@@ -29,6 +29,7 @@ const logsRemain = (logObjs) => {
 
 module.exports = (logSources, printer) => {
   // Create an array holding the source and next element for each log source
+  // Use array for O(1) time access with index
   // Space complexity is O(n) where n is number of log sources
   const logsObjArray = logSources.map((source) => {
     return {
@@ -42,13 +43,17 @@ module.exports = (logSources, printer) => {
   while(logsRemain(logsObjArray)) {
     const nextLogIndex = getIndexOfNextLogObject(logsObjArray);
 
-    if (!nextLogIndex) {
+    if (nextLogIndex === null) {
       break;
     }
 
     printer.print(logsObjArray[nextLogIndex].nextLog);
+
+    // Update next log at the index
     logsObjArray[nextLogIndex].nextLog = logsObjArray[nextLogIndex].source.pop();
   }
+
+  printer.done();
 
   return console.log("Sync sort complete.");
 };


### PR DESCRIPTION
Implementation for time-sorted log draining from multiple sources.

Each log source's log messages are in chronological order. The core design is one that gets the next log message for each source then, from among those, finds the earliest one by timestamp. The logic prints that message then pulls down the next message from just that source and searches the set of next log messages again for the earliest instance. This continues until all log sources are drained.

The asynchronous solution is similar but it must wait for all of the next log messages to arrive before it can determine which is the next in sequence. I had attempted a solution that "read ahead" in each log source but ended up with a race condition when trying to populate the next several log messages for each source without blocking the thread. I more correct solution for the async situation would spawn additional threads to read ahead and populate the next log messages so that the promises were resolved by the time they were needed. 